### PR TITLE
docs: clarify that match = true means perfect match with score 100

### DIFF
--- a/code/API_definitions/kyc-match.yaml
+++ b/code/API_definitions/kyc-match.yaml
@@ -91,7 +91,7 @@ paths:
         - If the provided `idDocument` does not match the one stored in the Operator systems, then a `HTTP 403 - KNOW_YOUR_CUSTOMER.ID_DOCUMENT_MISMATCH` error will be returned.
 
         The API will return the result of the matching process for each requested attribute. This means that the response will **only** contain the attributes for which validation has been requested. Possible values are:
-          - **true**: the attribute provided matches with the one in the Operator systems.
+          - **true**: the attribute provided matches with the one in the Operator systems, which is equal to a `match_score` of 100.
           - **false**: the attribute provided does not match with the one in the Operator systems.
           - **not_available**: the attribute is not available to validate.
       operationId: KYC_Match
@@ -328,16 +328,23 @@ components:
 
     MatchResult:
       type: string
+      description: |
+        true -  the attribute provided matches with the one in the Operator systems, which is equal to a `match_score` of 100.
+        false - the attribute provided does not match with the one in the Operator systems.
+        not_available - the attribute is not available to validate.
       enum:
-          - 'true'
-          - 'false'
-          - 'not_available'
+        - 'true'
+        - 'false'
+        - 'not_available'
 
     MatchScoreResult:
       type: integer
-      description: Indicates the similarity score assigned to the input value when it does not exactly match the value stored in the operator's system. This property shall only be returned when the value of the corresponding match field is `false`.
+      description: |
+        Indicates the similarity score assigned to the input value when it does not exactly match the value stored in the operator's system. 
+        This property shall only be returned when the value of the corresponding match field is `false`.
+        A perfect match with a score of 100 is indicated by `match` being 'true' and no `matchScore` is returned in this case.
       minimum: 0
-      maximum: 100
+      maximum: 99
 
     KYC_MatchResponse:
       type: object

--- a/code/Test_definitions/kyc-match.feature
+++ b/code/Test_definitions/kyc-match.feature
@@ -76,7 +76,7 @@ Feature: CAMARA Know Your Customer Match API, vwip - Operation KYC_Match
         And the response header "Content-Type" is "application/json"
         And the response body complies with the OAS schema at "/components/schemas/KYC_MatchResponse"
         And the response property "<response_property_path>" is equal to "false"
-        And the response property "<response_score_property_path>" is equal to an integer value between 0 and 100
+        And the response property "<response_score_property_path>" is equal to an integer value between 0 and 99
 
         Examples:
             | request_property_path     | response_property_path        | response_score_property_path  |
@@ -96,8 +96,37 @@ Feature: CAMARA Know Your Customer Match API, vwip - Operation KYC_Match
             | $.birthdate               | $.birthdateMatch              | $.birthdateMatchScore         |
             | $.email                   | $.emailMatch                  | $.emailMatchScore             |
 
+    @KYC_Match_4_perfect_match_no_scores_provided
+    Scenario Outline: Validate success response when providing specific property with true value
+        Given a valid testing phone number supported by the service, identified by the access token or provided in the request body
+        And the request body is set to a valid parameter combination with property "<request_property_path>" set to a valid formatted value that does perfectly match the value stored in the MNO system
+        When the request "KYC_Match" is sent
+        Then the response status code is 200
+        And the response header "x-correlator" has same value as the request header "x-correlator"
+        And the response header "Content-Type" is "application/json"
+        And the response body complies with the OAS schema at "/components/schemas/KYC_MatchResponse"
+        And the response property "<response_property_path>" is equal to "true"
+        And the response property "<response_score_property_path>" is not existing
 
-    @KYC_Match_4_success_multiple_optional_parameter_combinations
+        Examples:
+            | request_property_path     | response_property_path        | response_score_property_path  |
+            | $.idDocument              | $.idDocumentMatch             | $.idDocumentMatchScore        |
+            | $.name                    | $.nameMatch                   | $.nameMatchScore              |
+            | $.givenName               | $.givenNameMatch              | $.givenNameMatchScore         |
+            | $.familyName              | $.familyNameMatch             | $.familyNameMatchScore        |
+            | $.nameKanaHankaku         | $.nameKanaHankakuMatch        | $.nameKanaHankakuMatchScore   |
+            | $.nameKanaZenkaku         | $.nameKanaZenkakuMatch        | $.nameKanaZenkakuMatchScore   |
+            | $.middleNames             | $.middleNamesMatch            | $.middleNamesScore            |
+            | $.familyNameAtBirth       | $.familyNameAtBirthMatch      | $.familyNameAtBirthMatchScore |
+            | $.address                 | $.addressMatch                | $.addressMatchScore           |
+            | $.streetName              | $.streetNameMatch             | $.streetNameMatchScore        |
+            | $.streetNumber            | $.streetNumberMatch           | $.streetNumberMatchScore      |
+            | $.region                  | $.regionMatch                 | $.regionMatchScore            |
+            | $.locality                | $.localityMatch               | $.localityMatchScore          |
+            | $.birthdate               | $.birthdateMatch              | $.birthdateMatchScore         |
+            | $.email                   | $.emailMatch                  | $.emailMatchScore             |
+
+    @KYC_Match_5_success_multiple_optional_parameter_combinations
     Scenario: Validate success response when providing different optional parameter combinations
         Given a valid testing phone number supported by the service, identified by the access token or provided in the request body
         And the request body property "$.idDocument" is set to a valid identity document
@@ -126,7 +155,7 @@ Feature: CAMARA Know Your Customer Match API, vwip - Operation KYC_Match
         And the response header "Content-Type" is "application/json"
         And the response body complies with the OAS schema at "/components/schemas/KYC_MatchResponse"
 
-    @KYC_Match_5_success_id_document_required
+    @KYC_Match_6_success_id_document_required
     # Note: This test scenario is optional, as idDocument parameter and Second Level Validation is optional to network operators/ API providers.
     Scenario: Validate success when idDocument is required to perform the match validation for any other property
         Given a valid testing phone number supported by the service, identified by the access token or provided in the request body
@@ -217,7 +246,7 @@ Feature: CAMARA Know Your Customer Match API, vwip - Operation KYC_Match
     @KYC_Match_11_phone_number_provided_does_not_match_the_token
     Scenario: Error when the phone number provided in the request body does not match the phone number associated with the access token
         # To test this, a token has to be obtained for a different phoneNumber
-        Given the request body property "$.phoneNumber" is set to a valid testing phone number 
+        Given the request body property "$.phoneNumber" is set to a valid testing phone number
         And the header "Authorization" is set to a valid access token emitted for a different phone number
         When the request "KYC_Match" is sent
         Then the response status code is 403


### PR DESCRIPTION
#### What type of PR is this?

Add one of the following kinds:
* correction
* documentation
* tests


#### What this PR does / why we need it:

* Added detailed descriptions to MatchResult and MatchScoreResult fields in the OpenAPI spec.
* Specified that matchScore is only returned when match is 'false' with values between 0 and 99.
* Confirmed that match = true implies a perfect match and corresponds to a score of 100, with no score returned in that case.



#### Which issue(s) this PR fixes:

<!-- Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`. -->

Fixes #11
