### PR TITLE
fix: reset server URL to vwip on main (fixes #65)

### DIFF
--- a/code/API_definitions/kyc-match.yaml
+++ b/code/API_definitions/kyc-match.yaml
@@ -73,7 +73,7 @@ externalDocs:
   url: https://github.com/camaraproject/KnowYourCustomerMatch
 
 servers:
-  - url: '{apiRoot}/kyc-match/v0.4'
+  - url: '{apiRoot}/kyc-match/vwip'
     variables:
       apiRoot:
         default: http://localhost:9091


### PR DESCRIPTION
#### What type of PR is this?

correction

#### What this PR does / why we need it:

Resets the server URL on `main` to `vwip` after the previous release, per the standard CAMARA post-release procedure. `info.version` is already `wip`; only the server URL was lagging.

This is a mandatory prerequisite for the Release Automation roll-out: the framework requires `wip` / `vwip` versions on `main` so the release process can drive transitions to concrete versions on dedicated release branches.

One file updated, one line:

- `code/API_definitions/kyc-match.yaml`: server URL `v0.4` → `vwip`

#### Which issue(s) this PR fixes:

Fixes #65

#### Special notes for reviewers:

Mechanical wip reset. No semantic changes.

#### Changelog input

```
 release-note
Reset server URL on main to vwip (post-release procedure).
```

#### Additional documentation

This section can be blank.

```
docs

```
